### PR TITLE
Remove restriction "start with gpustat"; Display every host in their own <pre> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ python -m gpustat_web --port 48109 HOST1 [... HOSTN]
 
 Python 3.6+ is required.
 
+Python 3.7+ is recommended because you may encounter issues about Openssl and cryptography with python 3.6.
+
 [gpustat]: https://github.com/wookayin/gpustat/
 
 

--- a/gpustat_web/app.py
+++ b/gpustat_web/app.py
@@ -117,10 +117,10 @@ async def spawn_clients(hosts, exec_cmd, verbose=False):
 
 # monkey-patch ansi2html scheme. TODO: better color codes
 import ansi2html
-scheme = 'solarized'
+scheme = 'ansi2html'
 ansi2html.style.SCHEME[scheme] = list(ansi2html.style.SCHEME[scheme])
-ansi2html.style.SCHEME[scheme][0] = '#555555'
-ansi_conv = ansi2html.Ansi2HTMLConverter(dark_bg=True, scheme=scheme)
+#ansi2html.style.SCHEME[scheme][0] = '#555555'
+ansi_conv = ansi2html.Ansi2HTMLConverter(dark_bg=False, scheme=scheme)
 
 
 def render_gpustat_body():
@@ -128,8 +128,8 @@ def render_gpustat_body():
     for host, status in context.host_status.items():
         if not status:
             continue
-        body += status
-    return ansi_conv.convert(body, full=False)
+        body +="<pre class='ansi2html-content body_foreground body_background'>"+ansi_conv.convert( status,full=False)+"</pre>"
+    return body
 
 
 async def handler(request):

--- a/gpustat_web/app.py
+++ b/gpustat_web/app.py
@@ -177,8 +177,6 @@ async def websocket_handler(request):
 def create_app(loop, hosts=['localhost'], exec_cmd=None, verbose=True):
     if not exec_cmd:
         exec_cmd = 'gpustat --color'
-    if not exec_cmd.startswith('gpustat'):
-        raise ValueError("exec_cmd should start with gpustat!")
 
     app = web.Application()
     app.router.add_get('/', handler)

--- a/gpustat_web/template/index.html
+++ b/gpustat_web/template/index.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8"></meta>
+    <script src="https://cdn.staticfile.org/jquery/2.1.1/jquery.min.js"></script>
+    <link href="https://cdn.staticfile.org/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+    <title>gpustat-web</title>
     <style>
         body { overflow-x: scroll; }
         nav.header { font-family: monospace; margin-bottom: 10px; }
@@ -8,13 +12,13 @@
         nav.header a:hover { color: #a3daff; }
 
         #gpustat { line-height: 0.95; }
-        pre.ansi2html-content { white-space: pre; word-wrap: normal; }  /* no line break */
+        pre.ansi2html-content {display:block; white-space: pre; word-wrap: normal; }  /* no line break */
     </style>
 
     {{ ansi2html_headers | safe }}
   </head>
 
-  <body class="body_foreground body_background" style="font-size: normal;" >
+  <body  style="font-size: normal;" >
 
     <nav class="header">
       <a href="https://github.com/wookayin/gpustat-web" target="_blank">gpustat-web</a>
@@ -23,10 +27,8 @@
          onclick="this.style.display='none';">[turn off auto-refresh]</a>
     </nav>
 
-    <div id="gpustat">
-      <pre class="ansi2html-content" id="gpustat-content">
-      </pre>
-    </div>
+    <div id="gpustat" class="col-md-12">
+   </div>
 
   </body>
 
@@ -41,8 +43,8 @@
         };
         ws.onmessage = function(e) {
           var msg = e.data;
-          console.log('Received data, length = ' + msg.length + ', ' + new Date().toString());
-          document.getElementById('gpustat-content').innerHTML = msg;
+          //console.log('Received data, length = ' + msg.length + ', ' + new Date().toString());
+          document.getElementById('gpustat').innerHTML = msg;
         };
         window.onbeforeunload = function() {
           ws.close();  // close websocket client on exit


### PR DESCRIPTION
Python 3.6 works with OpenSSL 1.0.2, which doesn't support X25519. Updating to python 3.7 ( supporting OpenSSL 1.1.1) will solve this problem.

Some people may need full path to execute gpustat. Perhaps we can reduce restrictions.

