### PR TITLE
Add option to return json on websocket

### DIFF
--- a/gpustat_web/app.py
+++ b/gpustat_web/app.py
@@ -12,6 +12,7 @@ import os
 import sys
 import traceback
 import urllib
+import json
 
 import asyncio
 import asyncssh

--- a/gpustat_web/app.py
+++ b/gpustat_web/app.py
@@ -169,9 +169,10 @@ def render_gpustat_body_json():
             continue
         try:
             parsed = json.loads(status)
-        except:
+            body.append(parsed)
+        except Exception as e:
+            cprint(f"Coudn't parse {host} message as json. {e}", color='yellow')
             continue
-        body.append(parsed)
     return json.dumps(body)
 
 

--- a/gpustat_web/app.py
+++ b/gpustat_web/app.py
@@ -161,6 +161,18 @@ def render_gpustat_body():
         body += status
     return ansi_conv.convert(body, full=False)
 
+def render_gpustat_body_json():
+    body = []
+    for host, status in context.host_status.items():
+        if not status:
+            continue
+        try:
+            parsed = json.loads(status)
+        except:
+            continue
+        body.append(parsed)
+    return json.dumps(body)
+
 
 async def handler(request):
     '''Renders the html page.'''
@@ -184,6 +196,10 @@ async def websocket_handler(request):
     async def _handle_websocketmessage(msg):
         if msg.data == 'close':
             await ws.close()
+        elif msg.data == 'json':
+            # send json formatted string as a websocket message.
+            body = render_gpustat_body_json()
+            await ws.send_str(body)
         else:
             # send the rendered HTML body as a websocket message.
             body = render_gpustat_body()


### PR DESCRIPTION
I have added the option to also get the results as a json formatted string from the websocket by setting `ws.send_str('json')`.
json is more convenient for consuming in other applications, that are piggy-backing off of this library.

I have been using your gpustat & gpustat-web libraries for a while 😄 
~ Thank you ~