### PR TITLE
use packaging to compare version instead of distutils

### DIFF
--- a/gpustat_web/__init__.py
+++ b/gpustat_web/__init__.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse
 import sys
 import asyncssh
 
@@ -6,7 +6,7 @@ import asyncssh
 if sys.version_info < (3, 6):
     raise RuntimeError("Only Python 3.6+ is supported.")
 
-if LooseVersion(asyncssh.__version__) < LooseVersion("1.16"):
+if parse(asyncssh.__version__) < parse("1.16"):
     raise RuntimeError("asyncssh >= 1.16 is required. Please upgrade asyncssh.")
 
 # Entrypoint

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     'aiohttp_jinja2>=1.5',  # v1.5+ supports jinja2 v3.0
     'jinja2>=3.0.0',
     'aiohttp-devtools>=0.8',
+    'packaging',
 ]
 
 tests_requires = [


### PR DESCRIPTION
distutils [was removed in Python 3.12](https://docs.python.org/3/library/distutils.html), breaking gpustat_web (as it attempts to use distutils in `__init__.py` to check asyncssh's version.) This commit changes `__init__.py` to instead use the packaging module, [as recommended by PEP 632](https://peps.python.org/pep-0632/#migration-advice).